### PR TITLE
Add support for new locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mealie Planner is a self-hosted week-view meal planner for [Mealie](https://meal
 
 <img width="100%" alt="Screenshot of the Planner" src=".github/images/example.webp" />
 
-We want to make it incredibly simple to plan your meals for the week ahead. Manage your weekly meal plans with Mealie Planner. Share access and use the week-at-a-glance view.
+We want to make it incredibly simple to plan your meals for the week ahead. Manage your weekly meal plans with Mealie Planner. Share access and use the week-at-a-glance view. All in your native language.
 
 ## Installation
 

--- a/mealie-planner/README.md
+++ b/mealie-planner/README.md
@@ -8,14 +8,14 @@ A running Mealie instance accessible from your network, and a [Mealie API](https
 
 ## Configuration
 
-After starting the add-on, open the web UI. Enter your Mealie instance URL and API token in the settings panel. The add-on connects to Mealie over your local network and caches your recipe library for fast browsing. You can also configure the following variables from the Add-on settings instead:
+After starting the app, open the web UI. Enter your Mealie instance URL and API token in the settings panel. The app connects to Mealie over your local network and caches your recipe library for fast browsing. You can also configure the following variables from the app settings instead:
 
 | Option | Description |
 |---|---|
 | `mealie_url` | Base URL of your Mealie instance, e.g. `http://192.168.1.x:9000` |
 | `api_token` | Your Mealie API token (generated in Mealie under user settings) |
 
-After configuring your instance, your entire household can use the add-on. 
+After configuring your instance, your entire household can use the app using your preferred language.
 
 ## License
 

--- a/mealie-planner/assets/app.js
+++ b/mealie-planner/assets/app.js
@@ -1,7 +1,9 @@
 const RECIPES_STALE_MS = 5 * 60 * 1000;
 const PLAN_CACHE_TTL_MS = 5 * 60 * 1000;
-const SUPPORTED_LOCALES = ['en', 'de', 'nl', 'es', 'fr', 'it', 'pl'];
-const LOCALE_NAMES = { en: 'English', de: 'Deutsch', nl: 'Nederlands', es: 'Español', fr: 'Français', it: 'Italiano', pl: 'Polski' };
+
+/* For adding a new locale: add the translation (/assets/locales/<locale>.json) and add it to SUPPORTED_LOCALES and LOCALE_NAMES in `app.js` and update _SUPPORTED_LOCALES in `main.py` */
+const SUPPORTED_LOCALES = ['en', 'de', 'nl', 'es', 'fr', 'it', 'pl', 'ru', 'cs', 'sv', 'da', 'no', 'pt_BR'];
+const LOCALE_NAMES = { en: 'English', de: 'Deutsch', nl: 'Nederlands', es: 'Español', fr: 'Français', it: 'Italiano', pl: 'Polski', ru: 'Русский', cs: 'Čeština', sv: 'Svenska', da: 'Dansk', no: 'Norsk', pt_BR: 'Português (Brasil)' };
 
 function planner() {
   return {

--- a/mealie-planner/assets/locales/cs.json
+++ b/mealie-planner/assets/locales/cs.json
@@ -1,0 +1,158 @@
+{
+    "nav": {
+        "settings": "Nastavení",
+        "logout": "Odhlásit se",
+        "unreachable": "Nedostupné"
+    },
+    "theme": {
+        "system": "Systém",
+        "light": "Světlý",
+        "dark": "Tmavý"
+    },
+    "onboard": {
+        "title": "Co je tento týden v menu?",
+        "desc": "Připojte své prostředí Mealie, abyste mohli vyhledávat ve své knihovně receptů a plánovat jídla na týden přímo v Home Assistant."
+    },
+    "settings": {
+        "title": "Nastavení",
+        "connectionLabel": "Připojení k Mealie",
+        "dockerNotice": "Vše je připraveno! Toto je nakonfigurováno pomocí proměnných prostředí <code>MEALIE_API_URL</code> a <code>MEALIE_API_KEY</code>.",
+        "connected": "Připojeno k Mealie",
+        "unreachable": "Nakonfigurováno, ale Mealie je momentálně nedostupné",
+        "urlLabel": "URL adresa Mealie",
+        "tokenLabel": "API token",
+        "tokenPlaceholderUpdate": "Ponechte prázdné pro zachování aktuálního tokenu",
+        "tokenPlaceholderNew": "Váš Mealie API token",
+        "btnUpdate": "Aktualizovat",
+        "btnSave": "Uložit a ověřit",
+        "btnValidating": "Ověřování…",
+        "dayRangeLabel": "Rozsah dní",
+        "pastDays": "Zobrazit minulé dny · {n} dní",
+        "futureDays": "Zobrazit budoucí dny · {n} dní",
+        "tipKeyboard": "Tip! Použijte ← → pro posouvání po jednom týdnu.",
+        "mealSlotsLabel": "Zobrazit jídla",
+        "cacheLabel": "Knihovna receptů",
+        "cacheRefresh": "Obnovit",
+        "cacheRefreshing": "Obnovování…",
+        "recipesCount": "{n} uložených receptů",
+        "optionsLabel": "Možnosti",
+        "showQuickAdd": "Zobrazit tlačítko pro vytvoření a import",
+        "sourceLabel": "Zdroj",
+        "github": "Zobrazit na GitHubu",
+        "accentLabel": "Barva zvýraznění",
+        "languageLabel": "Jazyk"
+    },
+    "meal": {
+        "breakfast": "Snídaně",
+        "lunch": "Oběd",
+        "dinner": "Večeře",
+        "side": "Příloha"
+    },
+    "empty": {
+        "title": "Naplánujte si týden",
+        "desc": "Připojte svou sbírku receptů Mealie pro plánování jídel na týden.",
+        "btn": "Otevřít nastavení"
+    },
+    "planner": {
+        "retry": "Zkusit znovu",
+        "updatingPlan": "Aktualizace plánu jídel",
+        "today": "Dnes",
+        "remove": "Odstranit",
+        "openInMealie": "Otevřít v Mealie",
+        "open": "otevřít",
+        "openInMealieMobile": "otevřít v Mealie ↗",
+        "sparkleTitle": "Přidat náhodný recept",
+        "sparkle": "náhodně",
+        "addRecipe": "Přidat recept",
+        "changeRecipe": "změnit",
+        "addShort": "+ přidat",
+        "goToToday": "Dnes",
+        "noSlotsEnabled": "Nejsou aktivní žádné sloty pro jídla. Otevřete nastavení a přidejte je!",
+        "nothingPlanned": "Nic není naplánováno.",
+        "endOfRange": "60 dní dopředu",
+        "undo": "Zpět",
+        "prevPeriod": "Předchozí období",
+        "nextPeriod": "Další období"
+    },
+    "modal": {
+        "titleReplace": "Změnit recept",
+        "titleAdd": "Přidat recept",
+        "searchPlaceholder": "Hledat recepty…",
+        "refreshingRecipes": "Obnovování receptů",
+        "noMatch": "Nenalezeny žádné recepty pro \"{q}\"",
+        "loadingRecipes": "Načítání receptů…",
+        "feelingLucky": "Zkusím štěstí?",
+        "feelingLuckySub": "Vyberte mi náhodný recept",
+        "recentlyUsed": "Nedávno přidáno",
+        "badgeNew": "nové",
+        "badgeRecent": "nedávné",
+        "loadingMore": "načíst další…",
+        "close": "Zavřít"
+    },
+    "actions": {
+        "title": "Akce"
+    },
+    "logout": {
+        "title": "Odhlásit se?",
+        "desc": "Poté bude znovu vyžadován váš PIN.",
+        "cancel": "Zrušit",
+        "confirm": "Odhlásit se"
+    },
+    "toast": {
+        "removed": "{name} odstraněno",
+        "cacheRefreshed": "Knihovna synchronizována — {n} receptů.",
+        "actionSent": "Akce odeslána.",
+        "dismiss": "Zavřít"
+    },
+    "error": {
+        "backend": "Backend není dostupný. Běží server?",
+        "recipeCache": "Knihovnu receptů se nepodařilo načíst — obnovte ji v nastavení.",
+        "saveFailed": "Uložení selhalo — {detail}",
+        "removeFailed": "Odstranění selhalo — {detail}",
+        "sparkleFailed": "Přidání náhodného receptu selhalo — {detail}",
+        "undoFailed": "Akci zpět se nepodařilo provést.",
+        "cacheRefreshFailed": "Synchronizace knihovny selhala.",
+        "actionFailed": "Akce selhala — {detail}",
+        "loadMoreDays": "Další dny se nepodařilo načíst.",
+        "loadPlan": "Plán jídel se nepodařilo načíst.",
+        "moveFailed": "Přesun receptu selhal — {detail}",
+        "saveFallback": "Zkuste to prosím znovu.",
+        "sparkleFallback": "Žádné recepty v knihovně?",
+        "actionFallback": "Neznámá chyba",
+        "networkOffline": "Server není dostupný — zkontrolujte připojení a zkuste to znovu."
+    },
+    "quickAdd": {
+        "title": "Přidat do Mealie",
+        "tabUrl": "Importovat z webu",
+        "tabNew": "Nový recept",
+        "urlLabel": "URL adresa receptu",
+        "urlPlaceholder": "https://...",
+        "urlHint": "Vložte URL stránky s receptem. Mealie automaticky získá ingredience a postup — obvykle to trvá 10–20 sekund.",
+        "nameLabel": "Název receptu",
+        "namePlaceholder": "např. Babiččiny lasagne",
+        "imageLabel": "Fotografie (volitelné)",
+        "imagePlaceholder": "Vyberte obrázek…",
+        "btnImport": "Importovat",
+        "btnCreate": "Vytvořit recept",
+        "importing": "Načítání receptu… (obvykle 10–20 sekund)",
+        "creating": "Vytváření receptu…",
+        "btnCellShort": "+ nový recept",
+        "btnCellCreate": "nový recept",
+        "addedToSlot": "✦ {name} přidáno do plánu",
+        "errorUrlRequired": "Nejprve vložte URL stránky s receptem.",
+        "errorNameRequired": "Název receptu nesmí být prázdný.",
+        "errorAddedNotPlanned": "{name} bylo vytvořeno v Mealie, ale nebylo možné jej přidat do tohoto slotu — najděte jej přes + přidat.",
+        "openInMealie": "Otevřete v Mealie pro přidání ingrediencí a postupu ↗",
+        "proxyPrompt": "Webová stránka možná blokuje automatický přístup. Chcete stránku načíst přes tento server?",
+        "btnRetryProxy": "Zkusit znovu přes Mealie Planner"
+    },
+    "auth": {
+        "pageTitle": "Mealie Planner · Odemknout",
+        "title": "Zadejte PIN",
+        "subtitle": "Zadejte svůj PIN k odemčení Mealie Planneru.",
+        "btn": "Odemknout",
+        "errorShort": "Zadejte všech 6 znaků.",
+        "errorIncorrect": "Nesprávný PIN.",
+        "errorNetwork": "Chyba sítě. Zkuste to prosím znovu."
+    }
+}

--- a/mealie-planner/assets/locales/da.json
+++ b/mealie-planner/assets/locales/da.json
@@ -1,0 +1,158 @@
+{
+    "nav": {
+        "settings": "Indstillinger",
+        "logout": "Log ud",
+        "unreachable": "Ikke tilgængelig"
+    },
+    "theme": {
+        "system": "System",
+        "light": "Lyst",
+        "dark": "Mørkt"
+    },
+    "onboard": {
+        "title": "Hvad spiser vi i denne uge?",
+        "desc": "Forbind din Mealie-instans for at gennemse dit opskriftsbibliotek og planlæg måltider for ugen, direkte i Home Assistant."
+    },
+    "settings": {
+        "title": "Indstillinger",
+        "connectionLabel": "Mealie-forbindelse",
+        "dockerNotice": "Alt er klar! Disse konfigureres via miljøvariablerne <code>MEALIE_API_URL</code> og <code>MEALIE_API_KEY</code>.",
+        "connected": "Forbundet til Mealie",
+        "unreachable": "Konfigureret, men Mealie er ikke tilgængelig i øjeblikket",
+        "urlLabel": "Instans-URL",
+        "tokenLabel": "API-token",
+        "tokenPlaceholderUpdate": "Lad være tomt for at beholde nuværende token",
+        "tokenPlaceholderNew": "Din Mealie API-token",
+        "btnUpdate": "Opdater",
+        "btnSave": "Gem & valider",
+        "btnValidating": "Validerer…",
+        "dayRangeLabel": "Dagsinterval",
+        "pastDays": "Vis dage bagud · {n} dag(e)",
+        "futureDays": "Vis dage fremad · {n} dag(e)",
+        "tipKeyboard": "Tip! Brug ← → til at rulle én uge ad gangen.",
+        "mealSlotsLabel": "Synlige måltidspladser",
+        "cacheLabel": "Opskriftsbibliotek",
+        "cacheRefresh": "Opdater",
+        "cacheRefreshing": "Opdaterer…",
+        "recipesCount": "{n} opskrifter gemt",
+        "optionsLabel": "Indstillinger",
+        "showQuickAdd": "Vis knap til opret & importer",
+        "sourceLabel": "Kilde",
+        "github": "Besøg på GitHub",
+        "accentLabel": "Accentfarve",
+        "languageLabel": "Sprog"
+    },
+    "meal": {
+        "breakfast": "Morgenmad",
+        "lunch": "Frokost",
+        "dinner": "Aftensmad",
+        "side": "Tilbehør"
+    },
+    "empty": {
+        "title": "Planlæg din uge",
+        "desc": "Forbind din Mealie-opskriftssamling for at begynde at planlægge måltider for ugen.",
+        "btn": "Åbn indstillinger"
+    },
+    "planner": {
+        "retry": "Prøv igen",
+        "updatingPlan": "Opdaterer måltidsplan",
+        "today": "I dag",
+        "remove": "Fjern",
+        "openInMealie": "Åbn i Mealie",
+        "open": "åbn",
+        "openInMealieMobile": "åbn i Mealie ↗",
+        "sparkleTitle": "Tilføj tilfældig opskrift",
+        "sparkle": "tilfældig",
+        "addRecipe": "Tilføj opskrift",
+        "changeRecipe": "skift",
+        "addShort": "+ tilføj",
+        "goToToday": "I dag",
+        "noSlotsEnabled": "Ingen måltidspladser aktiveret. Åbn indstillinger for at tilføje!",
+        "nothingPlanned": "Intet planlagt.",
+        "endOfRange": "60 dage frem",
+        "undo": "Fortryd",
+        "prevPeriod": "Forrige periode",
+        "nextPeriod": "Næste periode"
+    },
+    "modal": {
+        "titleReplace": "Skift opskrift",
+        "titleAdd": "Tilføj opskrift",
+        "close": "Luk",
+        "searchPlaceholder": "Søg opskrifter…",
+        "refreshingRecipes": "Opdaterer opskrifter",
+        "noMatch": "Ingen opskrifter matcher \"{q}\"",
+        "loadingRecipes": "Indlæser opskrifter…",
+        "feelingLucky": "Føler du dig heldig?",
+        "feelingLuckySub": "Vælg en tilfældig opskrift til mig",
+        "recentlyUsed": "Nyligt tilføjet",
+        "badgeNew": "ny",
+        "badgeRecent": "nylig",
+        "loadingMore": "indlæser mere…"
+    },
+    "actions": {
+        "title": "Handlinger"
+    },
+    "logout": {
+        "title": "Log ud?",
+        "desc": "Din PIN-kode kræves igen.",
+        "cancel": "Annuller",
+        "confirm": "Log ud"
+    },
+    "toast": {
+        "removed": "Fjernede {name}",
+        "cacheRefreshed": "Bibliotek synkroniseret — {n} opskrifter.",
+        "actionSent": "Handling sendt.",
+        "dismiss": "Afvis"
+    },
+    "error": {
+        "backend": "Kunne ikke nå backend. Kører serveren?",
+        "recipeCache": "Kunne ikke indlæse opskriftsbiblioteket — prøv at opdatere det i indstillinger.",
+        "saveFailed": "Kunne ikke gemme — {detail}",
+        "removeFailed": "Kunne ikke fjerne — {detail}",
+        "sparkleFailed": "Tilfældig valg fejlede — {detail}",
+        "undoFailed": "Kunne ikke fortryde.",
+        "cacheRefreshFailed": "Bibliotekssynkronisering fejlede.",
+        "actionFailed": "Handling fejlede — {detail}",
+        "loadMoreDays": "Kunne ikke indlæse flere dage.",
+        "loadPlan": "Kunne ikke indlæse måltidsplan.",
+        "moveFailed": "Kunne ikke flytte opskrift — {detail}",
+        "saveFallback": "prøv igen.",
+        "sparkleFallback": "ingen opskrifter i biblioteket?",
+        "actionFallback": "ukendt fejl",
+        "networkOffline": "Kunne ikke nå serveren — tjek din forbindelse og prøv igen."
+    },
+    "quickAdd": {
+        "title": "Tilføj til Mealie",
+        "tabUrl": "Importer fra hjemmeside",
+        "tabNew": "Ny opskrift",
+        "urlLabel": "Opskrift-URL",
+        "urlPlaceholder": "https://...",
+        "urlHint": "Indsæt URL til en opskriftsside. Mealie henter ingredienser og trin automatisk — tager normalt 10–20 sekunder.",
+        "nameLabel": "Opskriftsnavn",
+        "namePlaceholder": "f.eks. Mormors lasagne",
+        "imageLabel": "Foto (valgfrit)",
+        "imagePlaceholder": "Vælg et billede…",
+        "btnImport": "Importer",
+        "btnCreate": "Opret opskrift",
+        "importing": "Henter opskrift… (normalt 10–20 sekunder)",
+        "creating": "Opretter opskrift…",
+        "btnCellShort": "+ ny opskrift",
+        "btnCellCreate": "ny opskrift",
+        "addedToSlot": "✦ {name} tilføjet til plan",
+        "errorUrlRequired": "Indsæt URL til en opskriftsside først.",
+        "errorNameRequired": "Opskriftsnavnet må ikke være tomt.",
+        "errorAddedNotPlanned": "{name} blev oprettet i Mealie, men kunne ikke tilføjes til denne plads — søg efter den med + tilføj.",
+        "openInMealie": "Åbn i Mealie for at tilføje ingredienser & trin ↗",
+        "proxyPrompt": "Hjemmesiden blokerer muligvis automatisk adgang. Vil du prøve at hente siden via denne server i stedet?",
+        "btnRetryProxy": "Prøv via Mealie Planner"
+    },
+    "auth": {
+        "pageTitle": "Mealie Planner · Lås op",
+        "title": "Indtast PIN",
+        "subtitle": "Indtast din PIN-kode for at låse Mealie Planner op.",
+        "btn": "Lås op",
+        "errorShort": "Indtast alle 6 tegn.",
+        "errorIncorrect": "Forkert PIN.",
+        "errorNetwork": "Netværksfejl. Prøv igen."
+    }
+}

--- a/mealie-planner/assets/locales/no.json
+++ b/mealie-planner/assets/locales/no.json
@@ -1,0 +1,158 @@
+{
+    "nav": {
+        "settings": "Innstillinger",
+        "logout": "Logg ut",
+        "unreachable": "Ikke tilgjengelig"
+    },
+    "theme": {
+        "system": "System",
+        "light": "Lyst",
+        "dark": "Mørkt"
+    },
+    "onboard": {
+        "title": "Hva skal vi spise denne uken?",
+        "desc": "Koble til din Mealie-instans for å bla gjennom oppskriftsbiblioteket og planlegge måltider for uken, rett i Home Assistant."
+    },
+    "settings": {
+        "title": "Innstillinger",
+        "connectionLabel": "Mealie-tilkobling",
+        "dockerNotice": "Alt er klart! Disse konfigureres via miljøvariablene <code>MEALIE_API_URL</code> og <code>MEALIE_API_KEY</code>.",
+        "connected": "Koblet til Mealie",
+        "unreachable": "Konfigurert, men Mealie er for øyeblikket ikke tilgjengelig",
+        "urlLabel": "Instans-URL",
+        "tokenLabel": "API-token",
+        "tokenPlaceholderUpdate": "La stå tomt for å beholde gjeldende token",
+        "tokenPlaceholderNew": "Din Mealie API-token",
+        "btnUpdate": "Oppdater",
+        "btnSave": "Lagre & valider",
+        "btnValidating": "Validerer…",
+        "dayRangeLabel": "Dagsintervall",
+        "pastDays": "Vis dager bakover · {n} dag(er)",
+        "futureDays": "Vis dager fremover · {n} dag(er)",
+        "tipKeyboard": "Tips! Bruk ← → for å bla én uke om gangen.",
+        "mealSlotsLabel": "Synlige måltidsplasser",
+        "cacheLabel": "Oppskriftsbibliotek",
+        "cacheRefresh": "Oppdater",
+        "cacheRefreshing": "Oppdaterer…",
+        "recipesCount": "{n} oppskrifter lagret",
+        "optionsLabel": "Alternativer",
+        "showQuickAdd": "Vis knapp for opprett & importer",
+        "sourceLabel": "Kilde",
+        "github": "Besøk på GitHub",
+        "accentLabel": "Aksentfarge",
+        "languageLabel": "Språk"
+    },
+    "meal": {
+        "breakfast": "Frokost",
+        "lunch": "Lunsj",
+        "dinner": "Middag",
+        "side": "Tilbehør"
+    },
+    "empty": {
+        "title": "Planlegg uken",
+        "desc": "Koble til din Mealie-oppskriftssamling for å begynne å planlegge måltider for uken.",
+        "btn": "Åpne innstillinger"
+    },
+    "planner": {
+        "retry": "Prøv igjen",
+        "updatingPlan": "Oppdaterer måltidsplan",
+        "today": "I dag",
+        "remove": "Fjern",
+        "openInMealie": "Åpne i Mealie",
+        "open": "åpne",
+        "openInMealieMobile": "åpne i Mealie ↗",
+        "sparkleTitle": "Legg til tilfeldig oppskrift",
+        "sparkle": "tilfeldig",
+        "addRecipe": "Legg til oppskrift",
+        "changeRecipe": "endre",
+        "addShort": "+ legg til",
+        "goToToday": "I dag",
+        "noSlotsEnabled": "Ingen måltidsplasser aktivert. Åpne innstillinger for å legge til!",
+        "nothingPlanned": "Ingenting planlagt.",
+        "endOfRange": "60 dager frem",
+        "undo": "Angre",
+        "prevPeriod": "Forrige periode",
+        "nextPeriod": "Neste periode"
+    },
+    "modal": {
+        "titleReplace": "Bytt oppskrift",
+        "titleAdd": "Legg til oppskrift",
+        "close": "Lukk",
+        "searchPlaceholder": "Søk oppskrifter…",
+        "refreshingRecipes": "Oppdaterer oppskrifter",
+        "noMatch": "Ingen oppskrifter matcher \"{q}\"",
+        "loadingRecipes": "Laster oppskrifter…",
+        "feelingLucky": "Føler du deg heldig?",
+        "feelingLuckySub": "Velg en tilfeldig oppskrift for meg",
+        "recentlyUsed": "Nylig lagt til",
+        "badgeNew": "ny",
+        "badgeRecent": "nylig",
+        "loadingMore": "laster mer…"
+    },
+    "actions": {
+        "title": "Handlinger"
+    },
+    "logout": {
+        "title": "Logg ut?",
+        "desc": "PIN-koden din kreves igjen.",
+        "cancel": "Avbryt",
+        "confirm": "Logg ut"
+    },
+    "toast": {
+        "removed": "Fjernet {name}",
+        "cacheRefreshed": "Bibliotek synkronisert — {n} oppskrifter.",
+        "actionSent": "Handling sendt.",
+        "dismiss": "Lukk"
+    },
+    "error": {
+        "backend": "Kunne ikke nå backend. Kjører serveren?",
+        "recipeCache": "Kunne ikke laste oppskriftsbiblioteket — prøv å oppdatere det i innstillinger.",
+        "saveFailed": "Kunne ikke lagre — {detail}",
+        "removeFailed": "Kunne ikke fjerne — {detail}",
+        "sparkleFailed": "Tilfeldig valg feilet — {detail}",
+        "undoFailed": "Kunne ikke angre.",
+        "cacheRefreshFailed": "Bibliotekssynkronisering feilet.",
+        "actionFailed": "Handling feilet — {detail}",
+        "loadMoreDays": "Kunne ikke laste flere dager.",
+        "loadPlan": "Kunne ikke laste måltidsplan.",
+        "moveFailed": "Kunne ikke flytte oppskrift — {detail}",
+        "saveFallback": "prøv igjen.",
+        "sparkleFallback": "ingen oppskrifter i biblioteket?",
+        "actionFallback": "ukjent feil",
+        "networkOffline": "Kunne ikke nå serveren — sjekk tilkoblingen og prøv igjen."
+    },
+    "quickAdd": {
+        "title": "Legg til i Mealie",
+        "tabUrl": "Importer fra nettside",
+        "tabNew": "Ny oppskrift",
+        "urlLabel": "Oppskrift-URL",
+        "urlPlaceholder": "https://...",
+        "urlHint": "Lim inn URL til en oppskriftsside. Mealie henter ingredienser og trinn automatisk — tar vanligvis 10–20 sekunder.",
+        "nameLabel": "Oppskriftsnavn",
+        "namePlaceholder": "f.eks. Bestemors lasagne",
+        "imageLabel": "Foto (valgfritt)",
+        "imagePlaceholder": "Velg et bilde…",
+        "btnImport": "Importer",
+        "btnCreate": "Opprett oppskrift",
+        "importing": "Henter oppskrift… (vanligvis 10–20 sekunder)",
+        "creating": "Oppretter oppskrift…",
+        "btnCellShort": "+ ny oppskrift",
+        "btnCellCreate": "ny oppskrift",
+        "addedToSlot": "✦ {name} lagt til i plan",
+        "errorUrlRequired": "Lim inn URL til en oppskriftsside først.",
+        "errorNameRequired": "Oppskriftsnavnet kan ikke være tomt.",
+        "errorAddedNotPlanned": "{name} ble opprettet i Mealie, men kunne ikke legges til i denne plassen — søk etter den med + legg til.",
+        "openInMealie": "Åpne i Mealie for å legge til ingredienser & trinn ↗",
+        "proxyPrompt": "Nettsiden kan blokkere automatisk tilgang. Vil du prøve å hente siden via denne serveren i stedet?",
+        "btnRetryProxy": "Prøv via Mealie Planner"
+    },
+    "auth": {
+        "pageTitle": "Mealie Planner · Lås opp",
+        "title": "Skriv inn PIN",
+        "subtitle": "Skriv inn PIN-koden din for å låse opp Mealie Planner.",
+        "btn": "Lås opp",
+        "errorShort": "Skriv inn alle 6 tegn.",
+        "errorIncorrect": "Feil PIN.",
+        "errorNetwork": "Nettverksfeil. Prøv igjen."
+    }
+}

--- a/mealie-planner/assets/locales/pt_BR.json
+++ b/mealie-planner/assets/locales/pt_BR.json
@@ -1,0 +1,158 @@
+{
+    "nav": {
+        "settings": "Configurações",
+        "logout": "Sair",
+        "unreachable": "Inacessível"
+    },
+    "theme": {
+        "system": "Sistema",
+        "light": "Claro",
+        "dark": "Escuro"
+    },
+    "onboard": {
+        "title": "O que vamos comer essa semana?",
+        "desc": "Conecte sua instância do Mealie para navegar pela sua biblioteca de receitas e planejar refeições para a semana, diretamente no Home Assistant."
+    },
+    "settings": {
+        "title": "Configurações",
+        "connectionLabel": "Conexão com o Mealie",
+        "dockerNotice": "Tudo pronto! Esses valores são configurados pelas variáveis de ambiente <code>MEALIE_API_URL</code> e <code>MEALIE_API_KEY</code>.",
+        "connected": "Conectado ao Mealie",
+        "unreachable": "Configurado, mas o Mealie está inacessível no momento",
+        "urlLabel": "URL da instância",
+        "tokenLabel": "Token da API",
+        "tokenPlaceholderUpdate": "Deixe em branco para manter o token atual",
+        "tokenPlaceholderNew": "Seu token da API do Mealie",
+        "btnUpdate": "Atualizar",
+        "btnSave": "Salvar & validar",
+        "btnValidating": "Validando…",
+        "dayRangeLabel": "Intervalo de dias",
+        "pastDays": "Mostrar dias anteriores · {n} dia(s)",
+        "futureDays": "Mostrar dias seguintes · {n} dia(s)",
+        "tipKeyboard": "Dica! Use ← → para avançar uma semana por vez.",
+        "mealSlotsLabel": "Slots de refeição visíveis",
+        "cacheLabel": "Biblioteca de receitas",
+        "cacheRefresh": "Atualizar",
+        "cacheRefreshing": "Atualizando…",
+        "recipesCount": "{n} receitas salvas",
+        "optionsLabel": "Opções",
+        "showQuickAdd": "Mostrar botão de criar & importar",
+        "sourceLabel": "Fonte",
+        "github": "Ver no GitHub",
+        "accentLabel": "Cor de destaque",
+        "languageLabel": "Idioma"
+    },
+    "meal": {
+        "breakfast": "Café da manhã",
+        "lunch": "Almoço",
+        "dinner": "Jantar",
+        "side": "Acompanhamento"
+    },
+    "empty": {
+        "title": "Planeje sua semana",
+        "desc": "Conecte sua coleção de receitas do Mealie para começar a planejar as refeições da semana.",
+        "btn": "Abrir configurações"
+    },
+    "planner": {
+        "retry": "Tentar novamente",
+        "updatingPlan": "Atualizando plano de refeições",
+        "today": "Hoje",
+        "remove": "Remover",
+        "openInMealie": "Abrir no Mealie",
+        "open": "abrir",
+        "openInMealieMobile": "abrir no Mealie ↗",
+        "sparkleTitle": "Adicionar receita aleatória",
+        "sparkle": "aleatório",
+        "addRecipe": "Adicionar receita",
+        "changeRecipe": "trocar",
+        "addShort": "+ adicionar",
+        "goToToday": "Hoje",
+        "noSlotsEnabled": "Nenhum slot de refeição ativado. Abra as configurações para adicionar!",
+        "nothingPlanned": "Nada planejado.",
+        "endOfRange": "60 dias à frente",
+        "undo": "Desfazer",
+        "prevPeriod": "Período anterior",
+        "nextPeriod": "Próximo período"
+    },
+    "modal": {
+        "titleReplace": "Trocar receita",
+        "titleAdd": "Adicionar receita",
+        "close": "Fechar",
+        "searchPlaceholder": "Buscar receitas…",
+        "refreshingRecipes": "Atualizando receitas",
+        "noMatch": "Nenhuma receita corresponde a \"{q}\"",
+        "loadingRecipes": "Carregando receitas…",
+        "feelingLucky": "Está se sentindo sortudo?",
+        "feelingLuckySub": "Escolha uma receita aleatória para mim",
+        "recentlyUsed": "Adicionadas recentemente",
+        "badgeNew": "novo",
+        "badgeRecent": "recente",
+        "loadingMore": "carregando mais…"
+    },
+    "actions": {
+        "title": "Ações"
+    },
+    "logout": {
+        "title": "Sair?",
+        "desc": "Seu PIN será solicitado novamente.",
+        "cancel": "Cancelar",
+        "confirm": "Sair"
+    },
+    "toast": {
+        "removed": "Removido {name}",
+        "cacheRefreshed": "Biblioteca sincronizada — {n} receitas.",
+        "actionSent": "Ação enviada.",
+        "dismiss": "Dispensar"
+    },
+    "error": {
+        "backend": "Falha ao acessar o backend. O servidor está em execução?",
+        "recipeCache": "Não foi possível carregar a biblioteca de receitas — tente atualizá-la nas configurações.",
+        "saveFailed": "Falha ao salvar — {detail}",
+        "removeFailed": "Falha ao remover — {detail}",
+        "sparkleFailed": "Receita aleatória falhou — {detail}",
+        "undoFailed": "Não foi possível desfazer.",
+        "cacheRefreshFailed": "Falha na sincronização da biblioteca.",
+        "actionFailed": "Ação falhou — {detail}",
+        "loadMoreDays": "Não foi possível carregar mais dias.",
+        "loadPlan": "Não foi possível carregar o plano de refeições.",
+        "moveFailed": "Falha ao mover receita — {detail}",
+        "saveFallback": "tente novamente.",
+        "sparkleFallback": "nenhuma receita na biblioteca?",
+        "actionFallback": "erro desconhecido",
+        "networkOffline": "Não foi possível alcançar o servidor — verifique sua conexão e tente novamente."
+    },
+    "quickAdd": {
+        "title": "Adicionar ao Mealie",
+        "tabUrl": "Importar de site",
+        "tabNew": "Nova receita",
+        "urlLabel": "URL da receita",
+        "urlPlaceholder": "https://...",
+        "urlHint": "Cole a URL de um site de receitas. O Mealie buscará os ingredientes e os passos automaticamente — geralmente leva 10–20 segundos.",
+        "nameLabel": "Nome da receita",
+        "namePlaceholder": "ex.: Lasanha da vovó",
+        "imageLabel": "Foto (opcional)",
+        "imagePlaceholder": "Escolha uma imagem…",
+        "btnImport": "Importar",
+        "btnCreate": "Criar receita",
+        "importing": "Buscando receita… (geralmente 10–20 segundos)",
+        "creating": "Criando receita…",
+        "btnCellShort": "+ nova receita",
+        "btnCellCreate": "nova receita",
+        "addedToSlot": "✦ {name} adicionado ao plano",
+        "errorUrlRequired": "Cole a URL de um site de receitas primeiro.",
+        "errorNameRequired": "O nome da receita não pode estar vazio.",
+        "errorAddedNotPlanned": "{name} foi criada no Mealie, mas não pôde ser adicionada a este slot — pesquise com + adicionar.",
+        "openInMealie": "Abrir no Mealie para adicionar ingredientes & passos ↗",
+        "proxyPrompt": "O site pode estar bloqueando acesso automatizado. Deseja tentar buscar a página por este servidor?",
+        "btnRetryProxy": "Tentar via Mealie Planner"
+    },
+    "auth": {
+        "pageTitle": "Mealie Planner · Desbloquear",
+        "title": "Digite o PIN",
+        "subtitle": "Digite seu PIN para desbloquear o Mealie Planner.",
+        "btn": "Desbloquear",
+        "errorShort": "Digite todos os 6 caracteres.",
+        "errorIncorrect": "PIN incorreto.",
+        "errorNetwork": "Erro de rede. Tente novamente."
+    }
+}

--- a/mealie-planner/assets/locales/ru.json
+++ b/mealie-planner/assets/locales/ru.json
@@ -1,0 +1,158 @@
+{
+    "nav": {
+        "settings": "Настройки",
+        "logout": "Выйти",
+        "unreachable": "Недоступно"
+    },
+    "theme": {
+        "system": "Системная",
+        "light": "Светлая",
+        "dark": "Темная"
+    },
+    "onboard": {
+        "title": "Что в меню на этой неделе?",
+        "desc": "Подключите вашу среду Mealie, чтобы искать рецепты и планировать питание на неделю прямо в Home Assistant."
+    },
+    "settings": {
+        "title": "Настройки",
+        "connectionLabel": "Подключение к Mealie",
+        "dockerNotice": "Все готово! Это настраивается через переменные окружения <code>MEALIE_API_URL</code> и <code>MEALIE_API_KEY</code>.",
+        "connected": "Подключено к Mealie",
+        "unreachable": "Настроено, но Mealie в данный момент недоступен",
+        "urlLabel": "URL-адрес Mealie",
+        "tokenLabel": "API-токен",
+        "tokenPlaceholderUpdate": "Оставьте пустым, чтобы сохранить текущий токен",
+        "tokenPlaceholderNew": "Ваш API-токен Mealie",
+        "btnUpdate": "Обновить",
+        "btnSave": "Сохранить и проверить",
+        "btnValidating": "Проверка…",
+        "dayRangeLabel": "Диапазон дней",
+        "pastDays": "Показывать прошедшие дни · {n} дн.",
+        "futureDays": "Показывать будущие дни · {n} дн.",
+        "tipKeyboard": "Подсказка! Используйте ← → для прокрутки по одной неделе.",
+        "mealSlotsLabel": "Показывать приемы пищи",
+        "cacheLabel": "Библиотека рецептов",
+        "cacheRefresh": "Обновить",
+        "cacheRefreshing": "Обновление…",
+        "recipesCount": "Сохранено рецептов: {n}",
+        "optionsLabel": "Опции",
+        "showQuickAdd": "Показывать кнопку создания и импорта",
+        "sourceLabel": "Источник",
+        "github": "Посмотреть на GitHub",
+        "accentLabel": "Цвет акцента",
+        "languageLabel": "Язык"
+    },
+    "meal": {
+        "breakfast": "Завтрак",
+        "lunch": "Обед",
+        "dinner": "Ужин",
+        "side": "Гарнир"
+    },
+    "empty": {
+        "title": "Спланируйте свою неделю",
+        "desc": "Подключите свою коллекцию рецептов Mealie, чтобы планировать приемы пищи на неделю.",
+        "btn": "Открыть настройки"
+    },
+    "planner": {
+        "retry": "Повторить попытку",
+        "updatingPlan": "Обновление плана питания",
+        "today": "Сегодня",
+        "remove": "Удалить",
+        "openInMealie": "Открыть в Mealie",
+        "open": "открыть",
+        "openInMealieMobile": "открыть в Mealie ↗",
+        "sparkleTitle": "Добавить случайный рецепт",
+        "sparkle": "случайно",
+        "addRecipe": "Добавить рецепт",
+        "changeRecipe": "изменить",
+        "addShort": "+ добавить",
+        "goToToday": "Сегодня",
+        "noSlotsEnabled": "Нет активных слотов для приемов пищи. Откройте настройки, чтобы добавить их!",
+        "nothingPlanned": "Ничего не запланировано.",
+        "endOfRange": "На 60 дней вперед",
+        "undo": "Отменить",
+        "prevPeriod": "Предыдущий период",
+        "nextPeriod": "Следующий период"
+    },
+    "modal": {
+        "titleReplace": "Изменить рецепт",
+        "titleAdd": "Добавить рецепт",
+        "searchPlaceholder": "Поиск рецептов…",
+        "refreshingRecipes": "Обновление рецептов",
+        "noMatch": "Рецепты по запросу \"{q}\" не найдены",
+        "loadingRecipes": "Загрузка рецептов…",
+        "feelingLucky": "Мне повезет?",
+        "feelingLuckySub": "Выбрать случайный рецепт для меня",
+        "recentlyUsed": "Недавно добавленные",
+        "badgeNew": "новое",
+        "badgeRecent": "недавнее",
+        "loadingMore": "загрузить еще…",
+        "close": "Закрыть"
+    },
+    "actions": {
+        "title": "Действия"
+    },
+    "logout": {
+        "title": "Выйти?",
+        "desc": "После этого потребуется снова ввести PIN-код.",
+        "cancel": "Отмена",
+        "confirm": "Выйти"
+    },
+    "toast": {
+        "removed": "{name} удален",
+        "cacheRefreshed": "Библиотека синхронизирована — {n} рецептов.",
+        "actionSent": "Действие отправлено.",
+        "dismiss": "Скрыть"
+    },
+    "error": {
+        "backend": "Бэкенд недоступен. Сервер запущен?",
+        "recipeCache": "Не удалось загрузить библиотеку рецептов — обновите в настройках.",
+        "saveFailed": "Ошибка сохранения — {detail}",
+        "removeFailed": "Ошибка удаления — {detail}",
+        "sparkleFailed": "Ошибка добавления случайного рецепта — {detail}",
+        "undoFailed": "Ошибка отмены.",
+        "cacheRefreshFailed": "Ошибка синхронизации библиотеки.",
+        "actionFailed": "Ошибка действия — {detail}",
+        "loadMoreDays": "Не удалось загрузить больше дней.",
+        "loadPlan": "Не удалось загрузить план питания.",
+        "moveFailed": "Ошибка перемещения рецепта — {detail}",
+        "saveFallback": "Попробуйте еще раз.",
+        "sparkleFallback": "В библиотеке нет рецептов?",
+        "actionFallback": "Неизвестная ошибка",
+        "networkOffline": "Сервер недоступен — проверьте подключение и повторите попытку."
+    },
+    "quickAdd": {
+        "title": "Добавить в Mealie",
+        "tabUrl": "Импорт с веб-сайта",
+        "tabNew": "Новый рецепт",
+        "urlLabel": "URL-адрес рецепта",
+        "urlPlaceholder": "https://...",
+        "urlHint": "Вставьте URL страницы с рецептом. Mealie автоматически извлечет ингредиенты и шаги — обычно это занимает 10–20 секунд.",
+        "nameLabel": "Название рецепта",
+        "namePlaceholder": "напр. Бабушкина лазанья",
+        "imageLabel": "Фото (необязательно)",
+        "imagePlaceholder": "Выберите изображение…",
+        "btnImport": "Импортировать",
+        "btnCreate": "Создать рецепт",
+        "importing": "Загрузка рецепта… (обычно 10–20 секунд)",
+        "creating": "Создание рецепта…",
+        "btnCellShort": "+ новый рецепт",
+        "btnCellCreate": "новый рецепт",
+        "addedToSlot": "✦ {name} добавлено в план",
+        "errorUrlRequired": "Сначала вставьте URL страницы с рецептом.",
+        "errorNameRequired": "Название рецепта не может быть пустым.",
+        "errorAddedNotPlanned": "{name} создано в Mealie, но не может быть добавлено в этот слот — найдите его через + добавить.",
+        "openInMealie": "Открыть в Mealie, чтобы добавить ингредиенты и шаги ↗",
+        "proxyPrompt": "Возможно, веб-сайт блокирует автоматический доступ. Хотите загрузить страницу через этот сервер?",
+        "btnRetryProxy": "Повторить попытку через Mealie Planner"
+    },
+    "auth": {
+        "pageTitle": "Mealie Planner · Разблокировать",
+        "title": "Введите PIN-код",
+        "subtitle": "Введите свой PIN-код, чтобы разблокировать Mealie Planner.",
+        "btn": "Разблокировать",
+        "errorShort": "Введите все 6 символов.",
+        "errorIncorrect": "Неверный PIN-код.",
+        "errorNetwork": "Ошибка сети. Попробуйте еще раз."
+    }
+}

--- a/mealie-planner/assets/locales/sv.json
+++ b/mealie-planner/assets/locales/sv.json
@@ -1,0 +1,158 @@
+{
+    "nav": {
+        "settings": "Inställningar",
+        "logout": "Logga ut",
+        "unreachable": "Ej nåbar"
+    },
+    "theme": {
+        "system": "System",
+        "light": "Ljust",
+        "dark": "Mörkt"
+    },
+    "onboard": {
+        "title": "Vad ska vi äta den här veckan?",
+        "desc": "Anslut din Mealie-instans för att bläddra i ditt receptbibliotek och planera måltider för veckan, direkt i Home Assistant."
+    },
+    "settings": {
+        "title": "Inställningar",
+        "connectionLabel": "Mealie-anslutning",
+        "dockerNotice": "Allt är klart! Dessa konfigureras via miljövariablerna <code>MEALIE_API_URL</code> och <code>MEALIE_API_KEY</code>.",
+        "connected": "Ansluten till Mealie",
+        "unreachable": "Konfigurerad men Mealie är för tillfället ej nåbar",
+        "urlLabel": "Instans-URL",
+        "tokenLabel": "API-token",
+        "tokenPlaceholderUpdate": "Lämna tomt för att behålla befintlig token",
+        "tokenPlaceholderNew": "Din Mealie API-token",
+        "btnUpdate": "Uppdatera",
+        "btnSave": "Spara & validera",
+        "btnValidating": "Validerar…",
+        "dayRangeLabel": "Dagintervall",
+        "pastDays": "Visa dagar bakåt · {n} dag(ar)",
+        "futureDays": "Visa dagar framåt · {n} dag(ar)",
+        "tipKeyboard": "Tips! Använd ← → för att bläddra en vecka i taget.",
+        "mealSlotsLabel": "Synliga måltidsplatser",
+        "cacheLabel": "Receptbibliotek",
+        "cacheRefresh": "Uppdatera",
+        "cacheRefreshing": "Uppdaterar…",
+        "recipesCount": "{n} recept sparade",
+        "optionsLabel": "Alternativ",
+        "showQuickAdd": "Visa knapp för skapa & importera",
+        "sourceLabel": "Källa",
+        "github": "Besök på GitHub",
+        "accentLabel": "Accentfärg",
+        "languageLabel": "Språk"
+    },
+    "meal": {
+        "breakfast": "Frukost",
+        "lunch": "Lunch",
+        "dinner": "Middag",
+        "side": "Tillbehör"
+    },
+    "empty": {
+        "title": "Planera veckan",
+        "desc": "Anslut din Mealie-receptsamling för att börja planera måltider för veckan.",
+        "btn": "Öppna inställningar"
+    },
+    "planner": {
+        "retry": "Försök igen",
+        "updatingPlan": "Uppdaterar måltidsplan",
+        "today": "Idag",
+        "remove": "Ta bort",
+        "openInMealie": "Öppna i Mealie",
+        "open": "öppna",
+        "openInMealieMobile": "öppna i Mealie ↗",
+        "sparkleTitle": "Lägg till slumpmässigt recept",
+        "sparkle": "slumpa",
+        "addRecipe": "Lägg till recept",
+        "changeRecipe": "ändra",
+        "addShort": "+ lägg till",
+        "goToToday": "Idag",
+        "noSlotsEnabled": "Inga måltidsplatser aktiverade. Öppna inställningar för att lägga till!",
+        "nothingPlanned": "Inget planerat.",
+        "endOfRange": "60 dagar framåt",
+        "undo": "Ångra",
+        "prevPeriod": "Föregående period",
+        "nextPeriod": "Nästa period"
+    },
+    "modal": {
+        "titleReplace": "Byt recept",
+        "titleAdd": "Lägg till recept",
+        "close": "Stäng",
+        "searchPlaceholder": "Sök recept…",
+        "refreshingRecipes": "Uppdaterar recept",
+        "noMatch": "Inga recept matchar \"{q}\"",
+        "loadingRecipes": "Laddar recept…",
+        "feelingLucky": "Känner du dig lyckosam?",
+        "feelingLuckySub": "Välj ett slumpmässigt recept åt mig",
+        "recentlyUsed": "Nyligen tillagda",
+        "badgeNew": "nytt",
+        "badgeRecent": "nyligen",
+        "loadingMore": "laddar mer…"
+    },
+    "actions": {
+        "title": "Åtgärder"
+    },
+    "logout": {
+        "title": "Logga ut?",
+        "desc": "Din PIN-kod krävs igen.",
+        "cancel": "Avbryt",
+        "confirm": "Logga ut"
+    },
+    "toast": {
+        "removed": "Tog bort {name}",
+        "cacheRefreshed": "Bibliotek synkroniserat — {n} recept.",
+        "actionSent": "Åtgärd skickad.",
+        "dismiss": "Stäng"
+    },
+    "error": {
+        "backend": "Kunde inte nå backend. Körs servern?",
+        "recipeCache": "Kunde inte ladda receptbiblioteket — försök uppdatera det i inställningar.",
+        "saveFailed": "Kunde inte spara — {detail}",
+        "removeFailed": "Kunde inte ta bort — {detail}",
+        "sparkleFailed": "Slumpen misslyckades — {detail}",
+        "undoFailed": "Kunde inte ångra.",
+        "cacheRefreshFailed": "Bibliotekssynkronisering misslyckades.",
+        "actionFailed": "Åtgärd misslyckades — {detail}",
+        "loadMoreDays": "Kunde inte ladda fler dagar.",
+        "loadPlan": "Kunde inte ladda måltidsplan.",
+        "moveFailed": "Kunde inte flytta recept — {detail}",
+        "saveFallback": "försök igen.",
+        "sparkleFallback": "inga recept i biblioteket?",
+        "actionFallback": "okänt fel",
+        "networkOffline": "Kunde inte nå servern — kontrollera anslutningen och försök igen."
+    },
+    "quickAdd": {
+        "title": "Lägg till i Mealie",
+        "tabUrl": "Importera från webbplats",
+        "tabNew": "Nytt recept",
+        "urlLabel": "Recept-URL",
+        "urlPlaceholder": "https://...",
+        "urlHint": "Klistra in URL till en receptsida. Mealie hämtar ingredienser och steg automatiskt — tar vanligtvis 10–20 sekunder.",
+        "nameLabel": "Receptnamn",
+        "namePlaceholder": "t.ex. Mormors lasagne",
+        "imageLabel": "Foto (valfritt)",
+        "imagePlaceholder": "Välj en bild…",
+        "btnImport": "Importera",
+        "btnCreate": "Skapa recept",
+        "importing": "Hämtar recept… (vanligtvis 10–20 sekunder)",
+        "creating": "Skapar recept…",
+        "btnCellShort": "+ nytt recept",
+        "btnCellCreate": "nytt recept",
+        "addedToSlot": "✦ {name} lagt till i plan",
+        "errorUrlRequired": "Klistra in URL:en till en receptsida först.",
+        "errorNameRequired": "Receptnamnet kan inte vara tomt.",
+        "errorAddedNotPlanned": "{name} skapades i Mealie men kunde inte läggas till i denna plats — sök efter det med + lägg till.",
+        "openInMealie": "Öppna i Mealie för att lägga till ingredienser & steg ↗",
+        "proxyPrompt": "Webbplatsen kan blockera automatisk åtkomst. Vill du försöka hämta sidan via den här servern istället?",
+        "btnRetryProxy": "Försök via Mealie Planner"
+    },
+    "auth": {
+        "pageTitle": "Mealie Planner · Lås upp",
+        "title": "Ange PIN",
+        "subtitle": "Ange din PIN-kod för att låsa upp Mealie Planner.",
+        "btn": "Lås upp",
+        "errorShort": "Ange alla 6 tecken.",
+        "errorIncorrect": "Felaktig PIN.",
+        "errorNetwork": "Nätverksfel. Försök igen."
+    }
+}

--- a/mealie-planner/main.py
+++ b/mealie-planner/main.py
@@ -244,7 +244,7 @@ _PIN_CODE = os.environ.get("PIN_CODE", "")
 _REQUIRE_AUTH = bool(_PIN_CODE)
 _SESSION_COOKIE = "mp_session"
 _SESSION_TTL = 86400 * 30
-_SUPPORTED_LOCALES = {"en", "de", "nl", "es", "fr", "it", "pl"}
+_SUPPORTED_LOCALES = {"en", "de", "nl", "es", "fr", "it", "pl", "ru", "cs", "sv", "da", "no", "pt_BR"}
 _LOCALE_OVERRIDE = os.environ.get("LOCALE", "").strip().lower()
 if _LOCALE_OVERRIDE not in _SUPPORTED_LOCALES:
     _LOCALE_OVERRIDE = ""


### PR DESCRIPTION
Include translations for Danish, Norwegian, Brazilian Portuguese, Russian, and Swedish to make sure Mealie Planner is more accessible to a broader audience.